### PR TITLE
Handling of grouping

### DIFF
--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.Tests/JeremyAnsel.Media.WavefrontObj.Tests.csproj
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.Tests/JeremyAnsel.Media.WavefrontObj.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0;net48</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
 
@@ -9,17 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PolySharp" Version="1.14.1">
+    <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.Tests/ObjFileReaderTests.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.Tests/ObjFileReaderTests.cs
@@ -1295,6 +1295,31 @@ p 1
 
             Assert.Equal("a", obj.Points[0].ObjectName);
         }
+        
+        
+
+        [Fact]
+        public void ObjectName_HandleObjectNamesAsGroup_SingleName_Valid()
+        {
+            string content = "o a";
+
+            var obj = ReadObj(content, new ObjFileReaderSettings { HandleObjectNamesAsGroup = true});
+
+            Assert.Single(obj.Groups);
+            Assert.Equal("a", obj.Groups[0].Name);
+        }
+
+        [Fact]
+        public void ObjectName_HandleObjectNamesAsGroup_MultipleNames_Valid()
+        {
+            string content = "o a b";
+
+            var obj = ReadObj(content, new ObjFileReaderSettings { HandleObjectNamesAsGroup = true});
+
+            Assert.Equal(2, obj.Groups.Count);
+            Assert.Equal("a", obj.Groups[0].Name);
+            Assert.Equal("b", obj.Groups[1].Name);
+        }
 
         [Fact]
         public void RenderAttributes_Bevel_Throws()
@@ -1653,13 +1678,13 @@ curv 0 1 1 2
             Assert.Throws<NotImplementedException>(() => ReadObj(statement));
         }
 
-        private static ObjFile ReadObj(string content)
+        private static ObjFile ReadObj(string content, ObjFileReaderSettings? settings = null)
         {
             var buffer = Encoding.UTF8.GetBytes(content);
 
             using (var stream = new MemoryStream(buffer, false))
             {
-                return ObjFile.FromStream(stream);
+                return ObjFile.FromStream(stream, settings ?? ObjFileReaderSettings.Default);
             }
         }
     }

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.Tests/ObjFileReaderTests.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.Tests/ObjFileReaderTests.cs
@@ -1206,6 +1206,17 @@ p 1
         }
 
         [Fact]
+        public void Group_MultipleNames_OnlyOneGroupNamePerLine_Valid()
+        {
+            string content = "g a b";
+
+            var obj = ReadObj(content, new ObjFileReaderSettings { OnlyOneGroupNamePerLine = true});
+
+            Assert.Single(obj.Groups);
+            Assert.Equal("a b", obj.Groups[0].Name);
+        }
+
+        [Fact]
         public void SmoothingGroup_Throws()
         {
             Assert.Throws<InvalidDataException>(() => ReadObj("s"));
@@ -1299,7 +1310,7 @@ p 1
         
 
         [Fact]
-        public void ObjectName_HandleObjectNamesAsGroup_SingleName_Valid()
+        public void ObjectName_SingleName_HandleObjectNamesAsGroup_Valid()
         {
             string content = "o a";
 
@@ -1310,7 +1321,7 @@ p 1
         }
 
         [Fact]
-        public void ObjectName_HandleObjectNamesAsGroup_MultipleNames_Valid()
+        public void ObjectName_MultipleNames_HandleObjectNamesAsGroup_Valid()
         {
             string content = "o a b";
 
@@ -1319,6 +1330,17 @@ p 1
             Assert.Equal(2, obj.Groups.Count);
             Assert.Equal("a", obj.Groups[0].Name);
             Assert.Equal("b", obj.Groups[1].Name);
+        }
+
+        [Fact]
+        public void ObjectName_OnlyOneGroupNamePerLine_HandleObjectNamesAsGroup_MultipleNames_Valid()
+        {
+            string content = "o a b";
+
+            var obj = ReadObj(content, new ObjFileReaderSettings { HandleObjectNamesAsGroup = true, OnlyOneGroupNamePerLine = true});
+
+            Assert.Single(obj.Groups);
+            Assert.Equal("a b", obj.Groups[0].Name);
         }
 
         [Fact]

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.csproj
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0;net48;netstandard2.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -41,12 +41,8 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' " >
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="PolySharp" Version="1.14.1">
+    <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -54,6 +50,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>    
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Numerics.Vectors" Version="4.6.0" />
   </ItemGroup>  
 
 </Project>

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFile.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFile.cs
@@ -71,6 +71,11 @@ namespace JeremyAnsel.Media.WavefrontObj
 
         public static ObjFile FromFile(string? path)
         {
+            return FromFile(path, ObjFileReaderSettings.Default);
+        }
+
+        public static ObjFile FromFile(string? path, ObjFileReaderSettings settings)
+        {
             if (path == null)
             {
                 throw new ArgumentNullException(nameof(path));
@@ -78,13 +83,18 @@ namespace JeremyAnsel.Media.WavefrontObj
 
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
-                return ObjFileReader.FromStream(stream);
+                return ObjFileReader.FromStream(stream, settings);
             }
         }
 
         public static ObjFile FromStream(Stream? stream)
         {
-            return ObjFileReader.FromStream(stream);
+            return FromStream(stream, ObjFileReaderSettings.Default);
+        }
+
+        public static ObjFile FromStream(Stream? stream, ObjFileReaderSettings settings)
+        {
+            return ObjFileReader.FromStream(stream, settings);
         }
 
         public void WriteTo(string? path)

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReader.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReader.cs
@@ -13,7 +13,7 @@ namespace JeremyAnsel.Media.WavefrontObj
     internal static class ObjFileReader
     {
         [SuppressMessage("Globalization", "CA1303:Ne pas passer de littéraux en paramètres localisés", Justification = "Reviewed.")]
-        public static ObjFile FromStream(Stream? stream)
+        public static ObjFile FromStream(Stream? stream, ObjFileReaderSettings settings)
         {
             if (stream == null)
             {
@@ -644,6 +644,11 @@ namespace JeremyAnsel.Media.WavefrontObj
                         break;
 
                     case "o":
+                        if (settings.HandleObjectNamesAsGroup)
+                        {
+                            ParseGroupName(values, context);
+                            break;
+                        }
                         if (values.Length == 1)
                         {
                             context.ObjectName = null;

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReader.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReader.cs
@@ -21,7 +21,7 @@ namespace JeremyAnsel.Media.WavefrontObj
             }
 
             var obj = new ObjFile();
-            var context = new ObjFileReaderContext(obj);
+            var context = new ObjFileReaderContext(obj, settings);
             var lineReader = new LineReader();
 
             foreach (var values in lineReader.Read(stream))
@@ -654,12 +654,11 @@ namespace JeremyAnsel.Media.WavefrontObj
                             context.ObjectName = null;
                             break;
                         }
-
                         if (values.Length != 2)
                         {
                             throw new InvalidDataException("A o statement has too many values.");
                         }
-
+                        
                         context.ObjectName = values[1];
                         break;
 
@@ -1117,13 +1116,25 @@ namespace JeremyAnsel.Media.WavefrontObj
         {
             context.GroupNames.Clear();
 
-            for (int i = 1; i < values.Length; i++)
+            if (context.Settings.OnlyOneGroupNamePerLine)
             {
-                var name = values[i];
-
+                var name = string.Join(" ", values, 1, values.Length - 1);
                 if (!string.Equals(name, "default", StringComparison.OrdinalIgnoreCase))
                 {
                     context.GroupNames.Add(name);
+                }
+                context.GroupNames.Add(name);
+            }
+            else
+            {
+                for (int i = 1; i < values.Length; i++)
+                {
+                    var name = values[i];
+
+                    if (!string.Equals(name, "default", StringComparison.OrdinalIgnoreCase))
+                    {
+                        context.GroupNames.Add(name);
+                    }
                 }
             }
 

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReaderContext.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReaderContext.cs
@@ -11,12 +11,15 @@ namespace JeremyAnsel.Media.WavefrontObj
     {
         private ObjFile obj;
 
-        public ObjFileReaderContext(ObjFile obj)
+        public ObjFileReaderContext(ObjFile obj, ObjFileReaderSettings settings)
         {
             this.obj = obj;
+            this.Settings = settings;
 
             this.GroupNames = new List<string>();
         }
+        
+        public ObjFileReaderSettings Settings { get; }
 
         public string? ObjectName { get; set; }
 

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReaderSettings.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReaderSettings.cs
@@ -18,4 +18,13 @@ public class ObjFileReaderSettings
     ///     This flag should be set to true, when object files should be interpreted like other libraries like three.js or tinyobjloader
     /// </remarks>
     public bool HandleObjectNamesAsGroup { get; set; } = false;
+
+    /// <summary>
+    ///     Normally multiple group names are valid per line e.g. "g group_name1 group_name1"
+    ///     If this flag is set to true, all after the g will be interpreted as a single group name
+    /// </summary>
+    /// <remarks>
+    ///     This flag should be set to true, when object files should be interpreted like other libraries like three.js or tinyobjloader
+    /// </remarks>
+    public bool OnlyOneGroupNamePerLine { get; set; } = false;
 }

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReaderSettings.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReaderSettings.cs
@@ -1,0 +1,21 @@
+namespace JeremyAnsel.Media.WavefrontObj;
+
+/// <summary>
+///     Settings to control the behaviour of the <see cref="ObjFileReader" />
+/// </summary>
+public class ObjFileReaderSettings
+{
+    /// <summary>
+    ///     Default settings
+    /// </summary>
+    public static readonly ObjFileReaderSettings Default = new();
+
+    /// <summary>
+    ///     Object names normally not interpreted as a <see cref="ObjGroup" />
+    ///     If this flag is set to true, object names are handled as a group.
+    /// </summary>
+    /// <remarks>
+    ///     This flag should be set to true, when object files should be interpreted like other libraries like three.js or tinyobjloader
+    /// </remarks>
+    public bool HandleObjectNamesAsGroup { get; set; } = false;
+}


### PR DESCRIPTION
Hi,
this pull requests adds a settings object for the ObjFileReader to define some behaviours.
Currently I have added and used the flag HandleObjNamesAsGroup and OnlyOneGroupNamePerLine.

I don't like to use this flag and liked the current behaviour which is close to the specification of the obj file. But I need to read obj files similar to other libraries (three.js, tinyobjloader). These interpret the 'o' flag as a group. These libraries handling only one group per line.