### PR TITLE
Group should only added once

### DIFF
--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReader.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReader.cs
@@ -1123,7 +1123,6 @@ namespace JeremyAnsel.Media.WavefrontObj
                 {
                     context.GroupNames.Add(name);
                 }
-                context.GroupNames.Add(name);
             }
             else
             {


### PR DESCRIPTION
Hi,
i'm sorry there is a bug in a the last pull request. Groups were added twice when using the OnlyOneGroupNamePerLine.
I have fixed this.