### PR TITLE
Settings for ObjMaterialReader added to handle each occurrence of groups as a new group

### DIFF
--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.Tests/JeremyAnsel.Media.WavefrontObj.Tests.csproj
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.Tests/JeremyAnsel.Media.WavefrontObj.Tests.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeCoverage" Version="18.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
-    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.Tests/ObjFileReaderTests.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.Tests/ObjFileReaderTests.cs
@@ -18,7 +18,7 @@ public class ObjFileReaderTests
     [Fact]
     public void Parsing_UnknownStatement_Valid()
     {
-        string content = "unknown";
+        const string content = "unknown";
         var exception = Record.Exception(() => ReadObj(content));
         Assert.Null(exception);
     }
@@ -26,7 +26,7 @@ public class ObjFileReaderTests
     [Fact]
     public void Parsing_UnknownoLongStatement_Valid()
     {
-        string content = "unknown_unknown_unknown_unknown";
+        const string content = "unknown_unknown_unknown_unknown";
         var exception = Record.Exception(() => ReadObj(content));
         Assert.Null(exception);
     }
@@ -34,7 +34,7 @@ public class ObjFileReaderTests
     [Fact]
     public void Parsing_UnknownSpacesStatement_Valid()
     {
-        string content = "unknown \t  \t\t 0";
+        const string content = "unknown \t  \t\t 0";
         var exception = Record.Exception(() => ReadObj(content));
         Assert.Null(exception);
     }
@@ -42,7 +42,7 @@ public class ObjFileReaderTests
     [Fact]
     public void Parsing_SpacesStatement_Valid()
     {
-        string content = "g \t  \t\t a";
+        const string content = "g \t  \t\t a";
 
         var obj = ReadObj(content);
 
@@ -53,16 +53,17 @@ public class ObjFileReaderTests
     [Fact]
     public void HeaderText_Valid()
     {
-        string content = @"
-# header line 1
-
-# header line 2
-
-# header \
-line 3
-g a
-# comment
-";
+        const string content = """
+                               
+                               # header line 1
+                               
+                               # header line 2
+                               
+                               # header \
+                               line 3
+                               g a
+                               # comment
+                               """;
 
         var obj = ReadObj(content);
 
@@ -88,11 +89,11 @@ g a
     [Fact]
     public void Parsing_Triplet1_Valid()
     {
-        string content = @"
-v 0 0 0
-v 0 0 0
-p 2
-";
+        const string content = """
+                               v 0 0 0
+                               v 0 0 0
+                               p 2
+                               """;
 
         var obj = ReadObj(content);
         var triplet = obj.Points[0].Vertices[0];
@@ -105,14 +106,14 @@ p 2
     [Fact]
     public void Parsing_Triplet2_Valid()
     {
-        string content = @"
-v 0 0 0
-v 0 0 0
-vt 0
-vt 0
-vt 0
-p 2/3/
-";
+        const string content = """
+                               v 0 0 0
+                               v 0 0 0
+                               vt 0
+                               vt 0
+                               vt 0
+                               p 2/3/
+                               """;
 
         var obj = ReadObj(content);
         var triplet = obj.Points[0].Vertices[0];
@@ -125,14 +126,14 @@ p 2/3/
     [Fact]
     public void Parsing_Triplet3_Valid()
     {
-        string content = @"
-v 0 0 0
-v 0 0 0
-vn 0 0 0
-vn 0 0 0
-vn 0 0 0
-p 2//3
-";
+        const string content = """
+                               v 0 0 0
+                               v 0 0 0
+                               vn 0 0 0
+                               vn 0 0 0
+                               vn 0 0 0
+                               p 2//3
+                               """;
 
         var obj = ReadObj(content);
         var triplet = obj.Points[0].Vertices[0];
@@ -145,18 +146,18 @@ p 2//3
     [Fact]
     public void Parsing_Triplet4_Valid()
     {
-        string content = @"
-v 0 0 0
-v 0 0 0
-vt 0
-vt 0
-vt 0
-vn 0 0 0
-vn 0 0 0
-vn 0 0 0
-vn 0 0 0
-p 2/3/4
-";
+        const string content = """
+                               v 0 0 0
+                               v 0 0 0
+                               vt 0
+                               vt 0
+                               vt 0
+                               vn 0 0 0
+                               vn 0 0 0
+                               vn 0 0 0
+                               vn 0 0 0
+                               p 2/3/4
+                               """;
 
         var obj = ReadObj(content);
         var triplet = obj.Points[0].Vertices[0];
@@ -179,9 +180,9 @@ p 2/3/4
     [Fact]
     public void Vertex_Geometric3_Valid()
     {
-        string content = @"
-v 2.0 3.0 4.0
-";
+        const string content = """
+                               v 2.0 3.0 4.0
+                               """;
 
         var obj = ReadObj(content);
 
@@ -192,9 +193,9 @@ v 2.0 3.0 4.0
     [Fact]
     public void Vertex_Geometric4_Valid()
     {
-        string content = @"
-v 2.0 3.0 4.0 5.0
-";
+        const string content = """
+                               v 2.0 3.0 4.0 5.0
+                               """;
 
         var obj = ReadObj(content);
 
@@ -205,9 +206,9 @@ v 2.0 3.0 4.0 5.0
     [Fact]
     public void Vertex_Geometric6_Valid()
     {
-        string content = @"
-v 2.0 3.0 4.0 5.0 6.0 7.0
-";
+        const string content = """
+                               v 2.0 3.0 4.0 5.0 6.0 7.0
+                               """;
 
         var obj = ReadObj(content);
 
@@ -218,9 +219,9 @@ v 2.0 3.0 4.0 5.0 6.0 7.0
     [Fact]
     public void Vertex_Geometric7_Valid()
     {
-        string content = @"
-v 2.0 3.0 4.0 5.0 6.0 7.0 8.0
-";
+        const string content = """
+                               v 2.0 3.0 4.0 5.0 6.0 7.0 8.0
+                               """;
 
         var obj = ReadObj(content);
 
@@ -238,9 +239,9 @@ v 2.0 3.0 4.0 5.0 6.0 7.0 8.0
     [Fact]
     public void Vertex_ParameterSpace1_Valid()
     {
-        string content = @"
-vp 2.0
-";
+        const string content = """
+                               vp 2.0
+                               """;
 
         var obj = ReadObj(content);
 
@@ -251,9 +252,9 @@ vp 2.0
     [Fact]
     public void Vertex_ParameterSpace2_Valid()
     {
-        string content = @"
-vp 2.0 3.0
-";
+        const string content = """
+                               vp 2.0 3.0
+                               """;
 
         var obj = ReadObj(content);
 
@@ -264,9 +265,9 @@ vp 2.0 3.0
     [Fact]
     public void Vertex_ParameterSpace3_Valid()
     {
-        string content = @"
-vp 2.0 3.0 4.0
-";
+        const string content = """
+                               vp 2.0 3.0 4.0
+                               """;
 
         var obj = ReadObj(content);
 
@@ -286,9 +287,9 @@ vp 2.0 3.0 4.0
     [Fact]
     public void Vertex_Normal_Valid()
     {
-        string content = @"
-vn 2.0 3.0 4.0
-";
+        const string content = """
+                               vn 2.0 3.0 4.0
+                               """;
 
         var obj = ReadObj(content);
 
@@ -306,9 +307,9 @@ vn 2.0 3.0 4.0
     [Fact]
     public void Vertex_Texture1_Valid()
     {
-        string content = @"
-vt 2.0
-";
+        const string content = """
+                               vt 2.0
+                               """;
 
         var obj = ReadObj(content);
 
@@ -319,9 +320,9 @@ vt 2.0
     [Fact]
     public void Vertex_Texture2_Valid()
     {
-        string content = @"
-vt 2.0 3.0
-";
+        const string content = """
+                               vt 2.0 3.0
+                               """;
 
         var obj = ReadObj(content);
 
@@ -332,9 +333,10 @@ vt 2.0 3.0
     [Fact]
     public void Vertex_Texture3_Valid()
     {
-        string content = @"
-vt 2.0 3.0 4.0
-";
+        const string content = """
+
+                               vt 2.0 3.0 4.0
+                               """;
 
         var obj = ReadObj(content);
 
@@ -365,12 +367,12 @@ vt 2.0 3.0 4.0
     [InlineData("rat taylor", true, ObjFreeFormType.Taylor)]
     public void FreeFormAttributes_Type_Valid(string value, bool rational, ObjFreeFormType type)
     {
-        string content = @"
-v 0 0 0
-v 0 0 0
-cstype " + value + @"
-curv 0 1 1 2
-";
+        string content = $"""
+                          v 0 0 0
+                          v 0 0 0
+                          cstype {value}
+                          curv 0 1 1 2
+                          """;
 
         var obj = ReadObj(content);
 
@@ -390,12 +392,12 @@ curv 0 1 1 2
     [InlineData("2 3", 2, 3)]
     public void FreeFormAttributes_Degree_Valid(string value, int u, int v)
     {
-        string content = @"
-v 0 0 0
-v 0 0 0
-deg " + value + @"
-curv 0 1 1 2
-";
+        string content = $"""
+                          v 0 0 0
+                          v 0 0 0
+                          deg {value}
+                          curv 0 1 1 2
+                          """;
 
         var obj = ReadObj(content);
 
@@ -416,13 +418,13 @@ curv 0 1 1 2
     [InlineData("v", 1)]
     public void FreeFormAttributes_BasisMatrix_Valid(string value, int index)
     {
-        string content = @"
-v 0 0 0
-v 0 0 0
-deg 2 3
-bmat " + value + @" 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0
-curv 0 1 1 2
-";
+        string content = $"""
+                          v 0 0 0
+                          v 0 0 0
+                          deg 2 3
+                          bmat {value} 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0
+                          curv 0 1 1 2
+                          """;
 
         var obj = ReadObj(content);
 
@@ -452,12 +454,12 @@ curv 0 1 1 2
     [InlineData("2.0 3.0", 2.0f, 3.0f)]
     public void FreeFormAttributes_Step_Valid(string value, float u, float v)
     {
-        string content = @"
-v 0 0 0
-v 0 0 0
-step " + value + @"
-curv 0 1 1 2
-";
+        string content = $"""
+                          v 0 0 0
+                          v 0 0 0
+                          step {value}
+                          curv 0 1 1 2
+                          """;
 
         var obj = ReadObj(content);
 
@@ -474,21 +476,21 @@ curv 0 1 1 2
     [Fact]
     public void Element_Point_Valid()
     {
-        string content = @"
-s 10
-o a
-g b
-lod 2
-usemap c
-usemtl d
-bevel on
-c_interp on
-d_interp on
-v 0 0 0
-v 0 0 0
-v 0 0 0
-p 2 3
-";
+        const string content = """
+                               s 10
+                               o a
+                               g b
+                               lod 2
+                               usemap c
+                               usemtl d
+                               bevel on
+                               c_interp on
+                               d_interp on
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               p 2 3
+                               """;
 
         var obj = ReadObj(content);
 
@@ -510,13 +512,13 @@ p 2 3
     [Fact]
     public void Element_PointDefaultGroup_Valid()
     {
-        string content = @"
-g default
-v 0 0 0
-v 0 0 0
-v 0 0 0
-p 2 3
-";
+        const string content = """
+                               g default
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               p 2 3
+                               """;
 
         var obj = ReadObj(content);
 
@@ -537,22 +539,22 @@ p 2 3
     [Fact]
     public void Element_Line_Valid()
     {
-        string content = @"
-s 10
-o a
-g b
-lod 2
-usemap c
-usemtl d
-bevel on
-c_interp on
-d_interp on
-v 0 0 0
-v 0 0 0
-v 0 0 0
-v 0 0 0
-l 2 3 4
-";
+        const string content = """
+                               s 10
+                               o a
+                               g b
+                               lod 2
+                               usemap c
+                               usemtl d
+                               bevel on
+                               c_interp on
+                               d_interp on
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               l 2 3 4
+                               """;
 
         var obj = ReadObj(content);
 
@@ -575,14 +577,14 @@ l 2 3 4
     [Fact]
     public void Element_LineDefaultGroup_Valid()
     {
-        string content = @"
-g default
-v 0 0 0
-v 0 0 0
-v 0 0 0
-v 0 0 0
-l 2 3 4
-";
+        const string content = """
+                               g default
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               l 2 3 4
+                               """;
 
         var obj = ReadObj(content);
 
@@ -609,24 +611,24 @@ l 2 3 4
     [InlineData("fo")]
     public void Element_Face_Valid(string statement)
     {
-        string content = @"
-s 10
-o a
-g b
-lod 2
-usemap c
-usemtl d
-bevel on
-c_interp on
-d_interp on
-v 0 0 0
-v 0 0 0
-v 0 0 0
-v 0 0 0
-v 0 0 0
-v 0 0 0
-" + statement + @" 2 3 4 5 6
-";
+        string content = $"""
+                          s 10
+                          o a
+                          g b
+                          lod 2
+                          usemap c
+                          usemtl d
+                          bevel on
+                          c_interp on
+                          d_interp on
+                          v 0 0 0
+                          v 0 0 0
+                          v 0 0 0
+                          v 0 0 0
+                          v 0 0 0
+                          v 0 0 0
+                          {statement} 2 3 4 5 6
+                          """;
 
         var obj = ReadObj(content);
 
@@ -653,16 +655,16 @@ v 0 0 0
     [InlineData("fo")]
     public void Element_FaceDefaultGroup_Valid(string statement)
     {
-        string content = @"
-g default
-v 0 0 0
-v 0 0 0
-v 0 0 0
-v 0 0 0
-v 0 0 0
-v 0 0 0
-" + statement + @" 2 3 4 5 6
-";
+        string content = $"""
+                          g default
+                          v 0 0 0
+                          v 0 0 0
+                          v 0 0 0
+                          v 0 0 0
+                          v 0 0 0
+                          v 0 0 0
+                          {statement} 2 3 4 5 6
+                          """;
 
         var obj = ReadObj(content);
 
@@ -691,21 +693,21 @@ v 0 0 0
     [Fact]
     public void Element_Curve_Valid()
     {
-        string content = @"
-mg 10 0
-o a
-g b
-lod 2
-usemap c
-usemtl d
-v 0 0 0
-v 0 0 0
-v 0 0 0
-v 0 0 0
-ctech cspace 0
-stech cspace 0
-curv 5.0 6.0 2 3 4
-";
+        const string content = """
+                               mg 10 0
+                               o a
+                               g b
+                               lod 2
+                               usemap c
+                               usemtl d
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               ctech cspace 0
+                               stech cspace 0
+                               curv 5.0 6.0 2 3 4
+                               """;
 
         var obj = ReadObj(content);
 
@@ -729,16 +731,16 @@ curv 5.0 6.0 2 3 4
     [Fact]
     public void Element_CurveDefaultGroup_Valid()
     {
-        string content = @"
-g default
-v 0 0 0
-v 0 0 0
-v 0 0 0
-v 0 0 0
-ctech cspace 0
-stech cspace 0
-curv 5.0 6.0 2 3 4
-";
+        const string content = """
+                               g default
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               ctech cspace 0
+                               stech cspace 0
+                               curv 5.0 6.0 2 3 4
+                               """;
 
         var obj = ReadObj(content);
 
@@ -767,21 +769,21 @@ curv 5.0 6.0 2 3 4
     [Fact]
     public void Element_Curve2D_Valid()
     {
-        string content = @"
-mg 10 0
-o a
-g b
-lod 2
-usemap c
-usemtl d
-vp 0 0 0
-vp 0 0 0
-vp 0 0 0
-vp 0 0 0
-ctech cspace 0
-stech cspace 0
-curv2 2 3 4
-";
+        const string content = """
+                               mg 10 0
+                               o a
+                               g b
+                               lod 2
+                               usemap c
+                               usemtl d
+                               vp 0 0 0
+                               vp 0 0 0
+                               vp 0 0 0
+                               vp 0 0 0
+                               ctech cspace 0
+                               stech cspace 0
+                               curv2 2 3 4
+                               """;
 
         var obj = ReadObj(content);
 
@@ -803,16 +805,16 @@ curv2 2 3 4
     [Fact]
     public void Element_Curve2DDefaultGroup_Valid()
     {
-        string content = @"
-g default
-vp 0 0 0
-vp 0 0 0
-vp 0 0 0
-vp 0 0 0
-ctech cspace 0
-stech cspace 0
-curv2 2 3 4
-";
+        const string content = """
+                               g default
+                               vp 0 0 0
+                               vp 0 0 0
+                               vp 0 0 0
+                               vp 0 0 0
+                               ctech cspace 0
+                               stech cspace 0
+                               curv2 2 3 4
+                               """;
 
         var obj = ReadObj(content);
 
@@ -842,21 +844,21 @@ curv2 2 3 4
     [Fact]
     public void Element_Surface_Valid()
     {
-        string content = @"
-mg 10 0
-o a
-g b
-lod 2
-usemap c
-usemtl d
-v 0 0 0
-v 0 0 0
-v 0 0 0
-v 0 0 0
-ctech cspace 0
-stech cspace 0
-surf 5.0 6.0 7.0 8.0 2 3 4
-";
+        const string content = """
+                               mg 10 0
+                               o a
+                               g b
+                               lod 2
+                               usemap c
+                               usemtl d
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               ctech cspace 0
+                               stech cspace 0
+                               surf 5.0 6.0 7.0 8.0 2 3 4
+                               """;
 
         var obj = ReadObj(content);
 
@@ -882,16 +884,16 @@ surf 5.0 6.0 7.0 8.0 2 3 4
     [Fact]
     public void Element_SurfaceDefaultGroup_Valid()
     {
-        string content = @"
-g default
-v 0 0 0
-v 0 0 0
-v 0 0 0
-v 0 0 0
-ctech cspace 0
-stech cspace 0
-surf 5.0 6.0 7.0 8.0 2 3 4
-";
+        const string content = """
+                               g default
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               v 0 0 0
+                               ctech cspace 0
+                               stech cspace 0
+                               surf 5.0 6.0 7.0 8.0 2 3 4
+                               """;
 
         var obj = ReadObj(content);
 
@@ -914,10 +916,11 @@ surf 5.0 6.0 7.0 8.0 2 3 4
     {
         ReadObj("parm");
 
-        string data = @"
-v 0 0 0
-curv 0 0 1 1
-";
+        string data = """
+                      v 0 0 0
+                      curv 0 0 1 1
+                      
+                      """;
 
         Assert.Throws<InvalidDataException>(() => ReadObj(data + "parm"));
         Assert.Throws<InvalidDataException>(() => ReadObj(data + "parm 0"));
@@ -930,12 +933,12 @@ curv 0 0 1 1
     [InlineData("v", 1)]
     public void FreeFormBody_Parameter_Valid(string value, int type)
     {
-        string content = @"
-v 0 0 0
-curv 0 0 1 1
-parm " + value + @" 2.0 3.0 4.0
-end
-";
+        string content = $"""
+                          v 0 0 0
+                          curv 0 0 1 1
+                          parm {value} 2.0 3.0 4.0 
+                          end
+                          """;
 
         var obj = ReadObj(content);
         List<float> parameters = type == 0 ? obj.Curves[0].ParametersU : obj.Curves[0].ParametersV;
@@ -951,10 +954,12 @@ end
     {
         ReadObj("trim");
 
-        string data = @"
-vp 0 0 0
-curv2 1 1
-";
+        string data = """
+
+                      vp 0 0 0
+                      curv2 1 1
+
+                      """;
 
         Assert.Throws<InvalidDataException>(() => ReadObj(data + "trim"));
         Assert.Throws<InvalidDataException>(() => ReadObj(data + "trim 0"));
@@ -969,16 +974,16 @@ curv2 1 1
     [Fact]
     public void FreeFormBody_Trim_Valid()
     {
-        string content = @"
-vp 0 0 0
-curv2 1 1
-curv2 1 1
-curv2 1 1
-v 0 0 0
-curv 0 0 1 1
-trim 4.0 5.0 2 6.0 7.0 3
-end
-";
+        const string content = """
+                               vp 0 0 0
+                               curv2 1 1
+                               curv2 1 1
+                               curv2 1 1
+                               v 0 0 0
+                               curv 0 0 1 1
+                               trim 4.0 5.0 2 6.0 7.0 3
+                               end
+                               """;
 
         var obj = ReadObj(content);
 
@@ -996,10 +1001,12 @@ end
     {
         ReadObj("hole");
 
-        string data = @"
-vp 0 0 0
-curv2 1 1
-";
+        string data = """
+
+                      vp 0 0 0
+                      curv2 1 1
+
+                      """;
 
         Assert.Throws<InvalidDataException>(() => ReadObj(data + "hole"));
         Assert.Throws<InvalidDataException>(() => ReadObj(data + "hole 0"));
@@ -1014,16 +1021,16 @@ curv2 1 1
     [Fact]
     public void FreeFormBody_Hole_Valid()
     {
-        string content = @"
-vp 0 0 0
-curv2 1 1
-curv2 1 1
-curv2 1 1
-v 0 0 0
-curv 0 0 1 1
-hole 4.0 5.0 2 6.0 7.0 3
-end
-";
+        const string content = """
+                               vp 0 0 0
+                               curv2 1 1
+                               curv2 1 1
+                               curv2 1 1
+                               v 0 0 0
+                               curv 0 0 1 1
+                               hole 4.0 5.0 2 6.0 7.0 3
+                               end
+                               """;
 
         var obj = ReadObj(content);
 
@@ -1041,10 +1048,12 @@ end
     {
         ReadObj("scrv");
 
-        string data = @"
-vp 0 0 0
-curv2 1 1
-";
+        string data = """
+
+                      vp 0 0 0
+                      curv2 1 1
+
+                      """;
 
         Assert.Throws<InvalidDataException>(() => ReadObj(data + "scrv"));
         Assert.Throws<InvalidDataException>(() => ReadObj(data + "scrv 0"));
@@ -1059,16 +1068,16 @@ curv2 1 1
     [Fact]
     public void FreeFormBody_Sequence_Valid()
     {
-        string content = @"
-vp 0 0 0
-curv2 1 1
-curv2 1 1
-curv2 1 1
-v 0 0 0
-curv 0 0 1 1
-scrv 4.0 5.0 2 6.0 7.0 3
-end
-";
+        const string content = """
+                               vp 0 0 0
+                               curv2 1 1
+                               curv2 1 1
+                               curv2 1 1
+                               v 0 0 0
+                               curv 0 0 1 1
+                               scrv 4.0 5.0 2 6.0 7.0 3
+                               end
+                               """;
 
         var obj = ReadObj(content);
 
@@ -1086,10 +1095,12 @@ end
     {
         ReadObj("sp");
 
-        string data = @"
-vp 0 0 0
-curv2 1 1
-";
+        string data = """
+
+                      vp 0 0 0
+                      curv2 1 1
+
+                      """;
 
         Assert.Throws<InvalidDataException>(() => ReadObj(data + "sp"));
         Assert.Throws<InvalidDataException>(() => ReadObj(data + "sp 0"));
@@ -1100,15 +1111,15 @@ curv2 1 1
     [Fact]
     public void FreeFormBody_SpecialPoints_Valid()
     {
-        string content = @"
-vp 0 0 0
-vp 0 0 0
-vp 0 0 0
-v 0 0 0
-curv 0 0 1 1
-sp 2 3
-end
-";
+        const string content = """
+                               vp 0 0 0
+                               vp 0 0 0
+                               vp 0 0 0
+                               v 0 0 0
+                               curv 0 0 1 1
+                               sp 2 3
+                               end
+                               """;
 
         var obj = ReadObj(content);
 
@@ -1130,12 +1141,13 @@ end
         Assert.Throws<InvalidDataException>(() => ReadObj("con 0 0 0 0 0 0 0"));
         Assert.Throws<InvalidDataException>(() => ReadObj("con 0 0 0 0 0 0 0 0 0"));
 
-        string data = @"
-v 0 0 0
-surf 0 0 0 0 1
-vp 0 0 0
-curv2 1 1
-";
+        const string data = """
+                            v 0 0 0
+                            surf 0 0 0 0 1
+                            vp 0 0 0
+                            curv2 1 1
+                            
+                            """;
 
         Assert.Throws<InvalidDataException>(() => ReadObj(data + "con 0 0 0 0 0 0 0 0"));
         Assert.Throws<IndexOutOfRangeException>(() => ReadObj(data + "con 2 0 0 0 0 0 0 0"));
@@ -1154,20 +1166,20 @@ curv2 1 1
     [Fact]
     public void SurfaceConnection_Valid()
     {
-        string content = @"
-v 0 0 0
-surf 0 0 0 0 1
-surf 0 0 0 0 1
-surf 0 0 0 0 1
-surf 0 0 0 0 1
-vp 0 0 0
-curv2 1 1
-curv2 1 1
-curv2 1 1
-curv2 1 1
-curv2 1 1
-con 2 6.0 7.0 3 4 8.0 9.0 5
-";
+        const string content = """
+                               v 0 0 0
+                               surf 0 0 0 0 1
+                               surf 0 0 0 0 1
+                               surf 0 0 0 0 1
+                               surf 0 0 0 0 1
+                               vp 0 0 0
+                               curv2 1 1
+                               curv2 1 1
+                               curv2 1 1
+                               curv2 1 1
+                               curv2 1 1
+                               con 2 6.0 7.0 3 4 8.0 9.0 5
+                               """;
 
         var obj = ReadObj(content);
 
@@ -1185,11 +1197,11 @@ con 2 6.0 7.0 3 4 8.0 9.0 5
     [Fact]
     public void Group_WithoutName_Valid()
     {
-        string content = @"
-g
-v 0 0 0
-p 1
-";
+        const string content = """
+                               g
+                               v 0 0 0
+                               p 1
+                               """;
 
         var obj = ReadObj(content);
 
@@ -1199,11 +1211,11 @@ p 1
     [Fact]
     public void Group_DefaultName_Valid()
     {
-        string content = @"
-g default
-v 0 0 0
-p 1
-";
+        const string content = """
+                               g default
+                               v 0 0 0
+                               p 1
+                               """;
 
         var obj = ReadObj(content);
 
@@ -1213,7 +1225,7 @@ p 1
     [Fact]
     public void Group_SingleName_Valid()
     {
-        string content = "g a";
+        const string content = "g a";
 
         var obj = ReadObj(content);
 
@@ -1224,7 +1236,7 @@ p 1
     [Fact]
     public void Group_MultipleNames_Valid()
     {
-        string content = "g a b";
+        const string content = "g a b";
 
         var obj = ReadObj(content);
 
@@ -1236,9 +1248,9 @@ p 1
     [Fact]
     public void Group_MultipleNames_OnlyOneGroupNamePerLine_Valid()
     {
-        string content = "g a b";
+        const string content = "g a b";
 
-        var obj = ReadObj(content, new ObjFileReaderSettings { OnlyOneGroupNamePerLine = true});
+        var obj = ReadObj(content, new ObjFileReaderSettings { OnlyOneGroupNamePerLine = true });
 
         Assert.Single(obj.Groups);
         Assert.Equal("a b", obj.Groups[0].Name);
@@ -1257,11 +1269,11 @@ p 1
     [InlineData("2", 2L)]
     public void SmoothingGroup_Valid(string value, long number)
     {
-        string content = @"
-s " + value + @"
-v 0 0 0
-p 1
-";
+        string content = $"""
+                          s {value}
+                          v 0 0 0
+                          p 1 
+                          """;
 
         var obj = ReadObj(content);
 
@@ -1283,12 +1295,12 @@ p 1
     [InlineData("2 3.0", 2, 3.0f)]
     public void MergingGroup_Valid(string value, int mg, float res)
     {
-        string content = @"
-mg " + value + @"
-v 0 0 0
-v 0 0 0
-curv 0 1 1 2
-";
+        string content = $"""
+                          mg {value}
+                          v 0 0 0
+                          v 0 0 0
+                          curv 0 1 1 2
+                          """;
 
         var obj = ReadObj(content);
 
@@ -1310,11 +1322,11 @@ curv 0 1 1 2
     [Fact]
     public void ObjectName_WithoutName_Valid()
     {
-        string content = @"
-o
-v 0 0 0
-p 1
-";
+        const string content = """
+                               o
+                               v 0 0 0
+                               p 1
+                               """;
 
         var obj = ReadObj(content);
 
@@ -1324,25 +1336,24 @@ p 1
     [Fact]
     public void ObjectName_Valid()
     {
-        string content = @"
-o a
-v 0 0 0
-p 1
-";
+        const string content = """
+                               o a
+                               v 0 0 0
+                               p 1
+                               """;
 
         var obj = ReadObj(content);
 
         Assert.Equal("a", obj.Points[0].ObjectName);
     }
-        
-        
+
 
     [Fact]
     public void ObjectName_SingleName_HandleObjectNamesAsGroup_Valid()
     {
-        string content = "o a";
+        const string content = "o a";
 
-        var obj = ReadObj(content, new ObjFileReaderSettings { HandleObjectNamesAsGroup = true});
+        var obj = ReadObj(content, new ObjFileReaderSettings { HandleObjectNamesAsGroup = true });
 
         Assert.Single(obj.Groups);
         Assert.Equal("a", obj.Groups[0].Name);
@@ -1351,9 +1362,9 @@ p 1
     [Fact]
     public void ObjectName_MultipleNames_HandleObjectNamesAsGroup_Valid()
     {
-        string content = "o a b";
+        const string content = "o a b";
 
-        var obj = ReadObj(content, new ObjFileReaderSettings { HandleObjectNamesAsGroup = true});
+        var obj = ReadObj(content, new ObjFileReaderSettings { HandleObjectNamesAsGroup = true });
 
         Assert.Equal(2, obj.Groups.Count);
         Assert.Equal("a", obj.Groups[0].Name);
@@ -1363,9 +1374,10 @@ p 1
     [Fact]
     public void ObjectName_OnlyOneGroupNamePerLine_HandleObjectNamesAsGroup_MultipleNames_Valid()
     {
-        string content = "o a b";
+        const string content = "o a b";
 
-        var obj = ReadObj(content, new ObjFileReaderSettings { HandleObjectNamesAsGroup = true, OnlyOneGroupNamePerLine = true});
+        var obj = ReadObj(content,
+            new ObjFileReaderSettings { HandleObjectNamesAsGroup = true, OnlyOneGroupNamePerLine = true });
 
         Assert.Single(obj.Groups);
         Assert.Equal("a b", obj.Groups[0].Name);
@@ -1384,11 +1396,11 @@ p 1
     [InlineData("off", false)]
     public void RenderAttributes_Bevel_Valid(string value, bool expected)
     {
-        string content = @"
-bevel " + value + @"
-v 0 0 0
-p 1
-";
+        string content = $"""
+                          bevel {value}
+                          v 0 0 0
+                          p 1
+                          """;
 
         var obj = ReadObj(content);
 
@@ -1408,11 +1420,11 @@ p 1
     [InlineData("off", false)]
     public void RenderAttributes_ColorInterpolation_Valid(string value, bool expected)
     {
-        string content = @"
-c_interp " + value + @"
-v 0 0 0
-p 1
-";
+        string content = $"""
+                          c_interp {value}
+                          v 0 0 0
+                          p 1
+                          """;
 
         var obj = ReadObj(content);
 
@@ -1432,11 +1444,11 @@ p 1
     [InlineData("off", false)]
     public void RenderAttributes_DissolveInterpolation_Valid(string value, bool expected)
     {
-        string content = @"
-d_interp " + value + @"
-v 0 0 0
-p 1
-";
+        string content = $"""
+                          d_interp {value}
+                          v 0 0 0
+                          p 1
+                          """;
 
         var obj = ReadObj(content);
 
@@ -1453,11 +1465,11 @@ p 1
     [Fact]
     public void RenderAttributes_LevelOfDetail_Valid()
     {
-        string content = @"
-lod 2
-v 0 0 0
-p 1
-";
+        const string content = """
+                               lod 2
+                               v 0 0 0
+                               p 1
+                               """;
 
         var obj = ReadObj(content);
 
@@ -1473,7 +1485,7 @@ p 1
     [Fact]
     public void RenderAttributes_MapLibrary_Valid()
     {
-        string content = "maplib a.a b";
+        const string content = "maplib a.a b";
 
         var obj = ReadObj(content);
 
@@ -1487,7 +1499,7 @@ p 1
     {
         Assert.Throws<InvalidDataException>(() => ReadObj("mtllib"));
     }
-        
+
     [Theory]
     [InlineData("a with spaces.b", "a with spaces.b", false)]
     [InlineData("a with spaces", "a with spaces", false)]
@@ -1496,9 +1508,9 @@ p 1
     [InlineData("a with  multiple   spaces.b", "a with  multiple   spaces.b", true)]
     public void RenderAttributes_MaterialLibrary_Valid(string value, string? expected, bool keepWhitespaces)
     {
-        string content = "mtllib "+value;
+        string content = "mtllib " + value;
 
-        var obj = ReadObj(content, new ObjFileReaderSettings { KeepWhitespacesOfMtlLibReferences = keepWhitespaces});
+        var obj = ReadObj(content, new ObjFileReaderSettings { KeepWhitespacesOfMtlLibReferences = keepWhitespaces });
 
         Assert.Single(obj.MaterialLibraries);
         Assert.Equal(expected, obj.MaterialLibraries[0]);
@@ -1516,11 +1528,11 @@ p 1
     [InlineData("a", "a")]
     public void RenderAttributes_UseMap_Valid(string value, string? expected)
     {
-        string content = @"
-usemap " + value + @"
-v 0 0 0
-p 1
-";
+        string content = $"""
+                          usemap {value}
+                          v 0 0 0
+                          p 1
+                          """;
 
         var obj = ReadObj(content);
 
@@ -1540,11 +1552,11 @@ p 1
     [InlineData("a with  multiple   spaces", "a with multiple spaces")]
     public void RenderAttributes_UseMaterial_Valid(string value, string? expected)
     {
-        string content = @"
-usemtl " + value + @"
-v 0 0 0
-p 1
-";
+        string content = $"""
+                          usemtl {value}
+                          v 0 0 0
+                          p 1
+                          """;
 
         var obj = ReadObj(content);
 
@@ -1560,7 +1572,7 @@ p 1
     [Fact]
     public void RenderAttributes_ShadowObject_Valid()
     {
-        string content = "shadow_obj a.a";
+        const string content = "shadow_obj a.a";
 
         var obj = ReadObj(content);
 
@@ -1570,7 +1582,7 @@ p 1
     [Fact]
     public void RenderAttributes_ShadowObject_ValidWithoutExtension()
     {
-        string content = "shadow_obj a";
+        const string content = "shadow_obj a";
 
         var obj = ReadObj(content);
 
@@ -1580,7 +1592,7 @@ p 1
     [Fact]
     public void RenderAttributes_ShadowObject_ValidWithExtensionIncludingWhitespace()
     {
-        string content = "shadow_obj a.a 0";
+        const string content = "shadow_obj a.a 0";
 
         var obj = ReadObj(content);
 
@@ -1596,7 +1608,7 @@ p 1
     [Fact]
     public void RenderAttributes_TraceObject_Valid()
     {
-        string content = "trace_obj a.a";
+        const string content = "trace_obj a.a";
 
         var obj = ReadObj(content);
 
@@ -1606,7 +1618,7 @@ p 1
     [Fact]
     public void RenderAttributes_TraceObject_ValidWithoutExtension()
     {
-        string content = "trace_obj a";
+        const string content = "trace_obj a";
 
         var obj = ReadObj(content);
 
@@ -1616,7 +1628,7 @@ p 1
     [Fact]
     public void RenderAttributes_TraceObject_ValidWithExtensionIncludingWhitespace()
     {
-        string content = "trace_obj a.a 0";
+        const string content = "trace_obj a.a 0";
 
         var obj = ReadObj(content);
 
@@ -1650,12 +1662,12 @@ p 1
     [InlineData("stech cparmb 2.0", 2.0f, 2.0f, 1)]
     public void RenderAttributes_ApproximationTechnique_Parametric_Valid(string value, float u, float v, int type)
     {
-        string content = @"
-v 0 0 0
-v 0 0 0
-" + value + @"
-curv 0 1 1 2
-";
+        string content = $"""
+                          v 0 0 0
+                          v 0 0 0
+                          {value}
+                          curv 0 1 1 2
+                          """;
 
         var obj = ReadObj(content);
 
@@ -1668,7 +1680,6 @@ curv 0 1 1 2
         else
         {
             technique = obj.Curves[0].SurfaceApproximationTechnique;
-
         }
 
         Assert.IsType<ObjConstantParametricSubdivisionTechnique>(technique);
@@ -1690,12 +1701,12 @@ curv 0 1 1 2
     [InlineData("stech cspace 2.0", 2.0f, 1)]
     public void RenderAttributes_ApproximationTechnique_Spatial_Valid(string value, float length, int type)
     {
-        string content = @"
-v 0 0 0
-v 0 0 0
-" + value + @"
-curv 0 1 1 2
-";
+        string content = $"""
+                          v 0 0 0
+                          v 0 0 0
+                          {value}
+                          curv 0 1 1 2
+                          """;
 
         var obj = ReadObj(content);
 
@@ -1708,7 +1719,6 @@ curv 0 1 1 2
         else
         {
             technique = obj.Curves[0].SurfaceApproximationTechnique;
-
         }
 
         Assert.IsType<ObjConstantSpatialSubdivisionTechnique>(technique);
@@ -1729,14 +1739,15 @@ curv 0 1 1 2
     [Theory]
     [InlineData("ctech curv 2.0 3.0", 2.0f, 3.0f, 0)]
     [InlineData("stech curv 2.0 3.0", 2.0f, 3.0f, 1)]
-    public void RenderAttributes_ApproximationTechnique_Curvature_Valid(string value, float distance, float angle, int type)
+    public void RenderAttributes_ApproximationTechnique_Curvature_Valid(string value, float distance, float angle,
+        int type)
     {
-        string content = @"
-v 0 0 0
-v 0 0 0
-" + value + @"
-curv 0 1 1 2
-";
+        string content = $"""
+                          v 0 0 0
+                          v 0 0 0
+                          {value}
+                          curv 0 1 1 2
+                          """;
 
         var obj = ReadObj(content);
 
@@ -1749,7 +1760,6 @@ curv 0 1 1 2
         else
         {
             technique = obj.Curves[0].SurfaceApproximationTechnique;
-
         }
 
         Assert.IsType<ObjCurvatureDependentSubdivisionTechnique>(technique);

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.Tests/ObjFileReaderTests.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.Tests/ObjFileReaderTests.cs
@@ -1257,6 +1257,54 @@ public class ObjFileReaderTests
     }
 
     [Fact]
+    public void Group_SameGroupOccurredTwice_ShouldCreateSingleGroup_WhenCreateNewGroupsForDuplicateGroupNamesIsFalse()
+    {
+        const string content = """
+                               v 1 1 1
+                               v 1 1 2
+                               v 1 1 3
+                               v 1 2 1
+                               v 1 2 2
+                               v 1 2 3
+                               g a
+                               p 1 2 3
+                               g a
+                               p 4 5 6
+                               """;
+
+        var obj = ReadObj(content, new ObjFileReaderSettings { HandleEachGroupOccurrenceAsNewGroup = false });
+
+        Assert.Single(obj.Groups);
+        Assert.Equal("a", obj.Groups[0].Name);
+        Assert.Equal(2, obj.Groups[0].Points.Count);
+    }
+
+    [Fact]
+    public void Group_SameGroupOccurredTwice_ShouldCreateSingleGroup_WhenCreateNewGroupsForDuplicateGroupNamesIsTrue()
+    {
+        const string content = """
+                               v 1 1 1
+                               v 1 1 2
+                               v 1 1 3
+                               v 1 2 1
+                               v 1 2 2
+                               v 1 2 3
+                               g a
+                               p 1 2 3
+                               g a
+                               p 4 5 6
+                               """;
+
+        var obj = ReadObj(content, new ObjFileReaderSettings { HandleEachGroupOccurrenceAsNewGroup = true });
+
+        Assert.Equal(2, obj.Groups.Count);
+        Assert.Equal("a", obj.Groups[0].Name);
+        Assert.Equal("a", obj.Groups[1].Name);
+        Assert.Single(obj.Groups[0].Points);
+        Assert.Single(obj.Groups[1].Points);
+    }
+
+    [Fact]
     public void SmoothingGroup_Throws()
     {
         Assert.Throws<InvalidDataException>(() => ReadObj("s"));
@@ -1381,6 +1429,54 @@ public class ObjFileReaderTests
 
         Assert.Single(obj.Groups);
         Assert.Equal("a b", obj.Groups[0].Name);
+    }
+
+    [Fact]
+    public void ObjectName_SameGroupOccurredTwice_ShouldCreateSingleGroup_WhenCreateNewGroupsForDuplicateGroupNamesIsFalse()
+    {
+        const string content = """
+                               v 1 1 1
+                               v 1 1 2
+                               v 1 1 3
+                               v 1 2 1
+                               v 1 2 2
+                               v 1 2 3
+                               o a
+                               p 1 2 3
+                               o a
+                               p 4 5 6
+                               """;
+
+        var obj = ReadObj(content, new ObjFileReaderSettings { HandleEachGroupOccurrenceAsNewGroup = false, HandleObjectNamesAsGroup = true});
+
+        Assert.Single(obj.Groups);
+        Assert.Equal("a", obj.Groups[0].Name);
+        Assert.Equal(2, obj.Groups[0].Points.Count);
+    }
+
+    [Fact]
+    public void ObjectName_SameGroupOccurredTwice_ShouldCreateSingleGroup_WhenCreateNewGroupsForDuplicateGroupNamesIsTrue()
+    {
+        const string content = """
+                               v 1 1 1
+                               v 1 1 2
+                               v 1 1 3
+                               v 1 2 1
+                               v 1 2 2
+                               v 1 2 3
+                               o a
+                               p 1 2 3
+                               o a
+                               p 4 5 6
+                               """;
+
+        var obj = ReadObj(content, new ObjFileReaderSettings { HandleEachGroupOccurrenceAsNewGroup = true, HandleObjectNamesAsGroup = true });
+
+        Assert.Equal(2, obj.Groups.Count);
+        Assert.Equal("a", obj.Groups[0].Name);
+        Assert.Equal("a", obj.Groups[1].Name);
+        Assert.Single(obj.Groups[0].Points);
+        Assert.Single(obj.Groups[1].Points);
     }
 
     [Fact]

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.csproj
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj.csproj
@@ -43,10 +43,6 @@
 
   <ItemGroup>
     <PackageReference Include="Equatable.Generator" Version="2.1.0" PrivateAssets="all" />
-    <PackageReference Condition="'$(CI)' == 'True'" Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
@@ -54,7 +50,7 @@
   </ItemGroup>
     
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Polyfill" Version="9.3.0">
+    <PackageReference Include="Polyfill" Version="9.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReader.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReader.cs
@@ -1114,7 +1114,7 @@ namespace JeremyAnsel.Media.WavefrontObj
                 }
             }
 
-            context.GetCurrentGroups();
+            context.CreateGroups();
         }
 
         private static ObjApproximationTechnique ParseApproximationTechnique(string[] values)

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReader9.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReader9.cs
@@ -1188,6 +1188,7 @@ namespace JeremyAnsel.Media.WavefrontObj
             }
         }
 
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         private static void ParseSurfaceConnection(ObjFile obj, ref ReadOnlySpan<char> currentLine, ref SpanSplitEnumerator values, int valuesCount)
         {
             if (valuesCount < 9)
@@ -1285,7 +1286,7 @@ namespace JeremyAnsel.Media.WavefrontObj
                 }
             }
 
-            context.GetCurrentGroups();
+            context.CreateGroups();
         }
 
         private static ObjApproximationTechnique ParseApproximationTechnique(ReadOnlySpan<char> value0, ref ReadOnlySpan<char> currentLine, ref SpanSplitEnumerator values, int valuesCount)

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReaderContext.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReaderContext.cs
@@ -18,7 +18,7 @@ internal class ObjFileReaderContext
 
         GroupNames = new List<string>();
     }
-        
+
     public ObjFileReaderSettings Settings { get; }
 
     public string? ObjectName { get; set; }
@@ -63,30 +63,41 @@ internal class ObjFileReaderContext
 
     public List<string> GroupNames { get; private set; }
 
+    private List<ObjGroup>? _currentGroups;
+
     public List<ObjGroup> GetCurrentGroups()
     {
-        var groups = new List<ObjGroup>();
+        if (_currentGroups is not null) return _currentGroups;
+        _currentGroups = [_obj.DefaultGroup];
+        return _currentGroups;
+    }
 
+    public void CreateGroups()
+    {
+        _currentGroups = new List<ObjGroup>();
         foreach (var name in this.GroupNames)
         {
-            var group = _obj.Groups.FirstOrDefault(t => string.Equals(t.Name, name, StringComparison.Ordinal));
+            ObjGroup? group = null;
+            if (!Settings.HandleEachGroupOccurrenceAsNewGroup)
+                group = GetGroupByName(name);
 
-            if (group == null)
+            if (group is null)
             {
                 group = new ObjGroup(name);
                 _obj.Groups.Add(group);
             }
 
-            groups.Add(group);
+            _currentGroups.Add(group);
         }
 
-        if (groups.Count == 0)
+        if (_currentGroups.Count == 0)
         {
-            groups.Add(_obj.DefaultGroup);
+            _currentGroups.Add(_obj.DefaultGroup);
         }
-
-        return groups;
     }
+
+    private ObjGroup? GetGroupByName(string name)
+        => _obj.Groups.Find(t => string.Equals(t.Name, name, StringComparison.Ordinal));
 
     public void ApplyAttributesToElement(ObjElement element)
     {

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReaderSettings.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileReaderSettings.cs
@@ -36,4 +36,23 @@ public class ObjFileReaderSettings
     ///     This flag should be set to true, when object files should be interpreted like other libraries like three.js or tinyobjloader
     /// </remarks>
     public bool KeepWhitespacesOfMtlLibReferences { get; set; } = false;
+
+    /// <summary>
+    ///     Normally groups are reused when the group name is used multiple times.
+    ///     If this flag is set to true, all group occurrences are handled as a different and new group
+    /// </summary>
+    /// <remarks>
+    ///     This flag should be set to true, when groups should be interpreted like other libraries like three.js or tinyobjloader
+    ///     The following example shows the difference between the default behavior and the behavior with this flag set to true:
+    ///     g cube
+    ///     f 1 2 3
+    ///     g other
+    ///     f 4 5 6
+    ///     g cube
+    ///     f 7 8 9
+    ///     When set to true: 3 groups are created (cube, other, cube)
+    ///     When set to false: 2 groups are created (cube, other). All faces of the second cube group are part of the first
+    ///     cube group.
+    /// </remarks>
+    public bool HandleEachGroupOccurrenceAsNewGroup { get; set; } = false;
 }

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileWriter.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileWriter.cs
@@ -117,7 +117,7 @@ internal static class ObjFileWriter
             {
                 var color = vertex.Color.Value;
 
-                if (color.W == 1.0f)
+                if (Math.Abs(color.W - 1.0f) < float.Epsilon)
                 {
                     stream.WriteLine(
                         "v {0} {1} {2} {3} {4} {5}",
@@ -143,7 +143,7 @@ internal static class ObjFileWriter
             }
             else
             {
-                if (position.W == 1.0f)
+                if (Math.Abs(position.W - 1.0f) < float.Epsilon)
                 {
                     stream.WriteLine(
                         "v {0} {1} {2}",
@@ -168,7 +168,7 @@ internal static class ObjFileWriter
     {
         foreach (var vertex in obj.ParameterSpaceVertices)
         {
-            if (vertex.Z == 1.0f)
+            if (Math.Abs(vertex.Z - 1.0f) < float.Epsilon)
             {
                 if (vertex.Y == 0.0f)
                 {

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileWriterContext.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjFileWriterContext.cs
@@ -280,7 +280,7 @@ internal class ObjFileWriterContext
             stream.WriteLine();
         }
 
-        if (element.StepV == 1.0f)
+        if (Math.Abs(element.StepV - 1.0f) < float.Epsilon)
         {
             stream.WriteLine(
                 "step {0}",
@@ -322,7 +322,7 @@ internal class ObjFileWriterContext
             {
                 var technique = (ObjConstantParametricSubdivisionTechnique)element.SurfaceApproximationTechnique;
 
-                if (technique.ResolutionU == technique.ResolutionV)
+                if (Math.Abs(technique.ResolutionU - technique.ResolutionV) < float.Epsilon)
                 {
                     stream.WriteLine(
                         "stech cparmb {0}",

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjMaterialColor.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjMaterialColor.cs
@@ -36,6 +36,7 @@ public class ObjMaterialColor
 
     public ObjVector3 Color { get; set; }
 
+    // ReSharper disable once InconsistentNaming
     public bool UseXYZColorSpace { get; set; }
 
     public string? SpectralFileName { get; set; }
@@ -50,8 +51,10 @@ public class ObjMaterialColor
         }
     }
 
+    // ReSharper disable once InconsistentNaming
     public bool IsRGB => !IsSpectral && !UseXYZColorSpace;
 
+    // ReSharper disable once InconsistentNaming
     public bool IsXYZ => !IsSpectral && UseXYZColorSpace;
 
     private string ToDebuggerDisplayString()

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjMaterialFileReader.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjMaterialFileReader.cs
@@ -572,69 +572,69 @@ namespace JeremyAnsel.Media.WavefrontObj
                     break;
 
                 case "xyz":
+                {
+                    index++;
+
+                    if (values.Length - index < 1)
                     {
-                        index++;
-
-                        if (values.Length - index < 1)
-                        {
-                            throw new InvalidDataException(string.Concat("A ", statement, " xyz statement must specify a color."));
-                        }
-
-                        color.UseXYZColorSpace = true;
-
-                        var xyz = new ObjVector3();
-
-                        xyz.X = float.Parse(values[index], CultureInfo.InvariantCulture);
-                        index++;
-
-                        if (values.Length > index)
-                        {
-                            if (values.Length - index < 2)
-                            {
-                                throw new InvalidDataException(string.Concat("A ", statement, " xyz statement must specify a XYZ color."));
-                            }
-
-                            xyz.Y = float.Parse(values[index], CultureInfo.InvariantCulture);
-                            xyz.Z = float.Parse(values[index + 1], CultureInfo.InvariantCulture);
-                            index += 2;
-                        }
-                        else
-                        {
-                            xyz.Y = xyz.X;
-                            xyz.Z = xyz.X;
-                        }
-
-                        color.Color = xyz;
-                        break;
+                        throw new InvalidDataException(string.Concat("A ", statement, " xyz statement must specify a color."));
                     }
+
+                    color.UseXYZColorSpace = true;
+
+                    var xyz = new ObjVector3();
+
+                    xyz.X = float.Parse(values[index], CultureInfo.InvariantCulture);
+                    index++;
+
+                    if (values.Length > index)
+                    {
+                        if (values.Length - index < 2)
+                        {
+                            throw new InvalidDataException(string.Concat("A ", statement, " xyz statement must specify a XYZ color."));
+                        }
+
+                        xyz.Y = float.Parse(values[index], CultureInfo.InvariantCulture);
+                        xyz.Z = float.Parse(values[index + 1], CultureInfo.InvariantCulture);
+                        index += 2;
+                    }
+                    else
+                    {
+                        xyz.Y = xyz.X;
+                        xyz.Z = xyz.X;
+                    }
+
+                    color.Color = xyz;
+                    break;
+                }
 
                 default:
+                {
+                    var rgb = new ObjVector3();
+
+                    rgb.X = float.Parse(values[index], CultureInfo.InvariantCulture);
+                    index++;
+
+                    if (values.Length > index)
                     {
-                        var rgb = new ObjVector3();
-
-                        rgb.X = float.Parse(values[index], CultureInfo.InvariantCulture);
-                        index++;
-
-                        if (values.Length > index)
+                        if (values.Length - index < 2)
                         {
-                            if (values.Length - index < 2)
-                            {
-                                throw new InvalidDataException(string.Concat("A ", statement, " statement must specify a RGB color."));
-                            }
-
-                            rgb.Y = float.Parse(values[index], CultureInfo.InvariantCulture);
-                            rgb.Z = float.Parse(values[index + 1], CultureInfo.InvariantCulture);
-                            index += 2;
-                        }
-                        else
-                        {
-                            rgb.Y = rgb.X;
-                            rgb.Z = rgb.X;
+                            throw new InvalidDataException(string.Concat("A ", statement, " statement must specify a RGB color."));
                         }
 
-                        color.Color = rgb;
-                        break;
+                        rgb.Y = float.Parse(values[index], CultureInfo.InvariantCulture);
+                        rgb.Z = float.Parse(values[index + 1], CultureInfo.InvariantCulture);
+                        index += 2;
                     }
+                    else
+                    {
+                        rgb.Y = rgb.X;
+                        rgb.Z = rgb.X;
+                    }
+
+                    color.Color = rgb;
+                    break;
+                }
             }
 
             if (index != values.Length)
@@ -854,18 +854,13 @@ namespace JeremyAnsel.Media.WavefrontObj
                                 map.Offset = offset;
                                 break;
                             }
-                            
+
                             if (values.Length - index > 2)
                             {
                                 if (float.TryParse(values[index + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out v))
                                 {
                                     offset.Z = v;
                                     index++;
-                                }
-                                else
-                                {
-                                    map.Offset = offset;
-                                    break;
                                 }
                             }
                         }
@@ -874,66 +869,74 @@ namespace JeremyAnsel.Media.WavefrontObj
                         break;
 
                     case "-s":
+                    {
+                        if (values.Length - index < 2)
                         {
-                            if (values.Length - index < 2)
-                            {
-                                throw new InvalidDataException(string.Concat("A ", statement, " -s option must specify at least 2 values."));
-                            }
-
-                            var scale = new ObjVector3(1.0f, 1.0f, 1.0f);
-
-                            scale.X = float.Parse(values[index + 1], CultureInfo.InvariantCulture);
-                            index++;
-
-                            if (values.Length - index > 2)
-                            {
-                                if (float.TryParse(values[index + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out var v))
-                                {
-                                    scale.Y = v;
-                                    index++;
-                                }
-                                else
-                                {
-                                    map.Scale = scale;
-                                    break;
-                                }
-                            
-                                if (values.Length - index > 2)
-                                {
-                                    if (float.TryParse(values[index + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out v))
-                                    {
-                                        scale.Z = v;
-                                        index++;
-                                    }
-                                    else
-                                    {
-                                        map.Scale = scale;
-                                        break;
-                                    }
-                                }
-                            }
-
-                            map.Scale = scale;
-                            break;
+                            throw new InvalidDataException(string.Concat("A ", statement, " -s option must specify at least 2 values."));
                         }
 
-                    case "-t":
+                        var scale = new ObjVector3(1.0f, 1.0f, 1.0f);
+
+                        scale.X = float.Parse(values[index + 1], CultureInfo.InvariantCulture);
+                        index++;
+
+                        if (values.Length - index > 2)
                         {
-                            if (values.Length - index < 2)
+                            if (float.TryParse(values[index + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out var v))
                             {
-                                throw new InvalidDataException(string.Concat("A ", statement, " -t option must specify at least 2 values."));
+                                scale.Y = v;
+                                index++;
                             }
-
-                            var turbulence = new ObjVector3();
-
-                            turbulence.X = float.Parse(values[index + 1], CultureInfo.InvariantCulture);
-                            index++;
+                            else
+                            {
+                                map.Scale = scale;
+                                break;
+                            }
 
                             if (values.Length - index > 2)
                             {
-                                if (float.TryParse(values[index + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out var v))
+                                if (float.TryParse(values[index + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out v))
                                 {
-                                    turbulence.Y = v;
+                                    scale.Z = v;
+                                    index++;
+                                }
+                            }
+                        }
+
+                        map.Scale = scale;
+                        break;
+                    }
+
+                    case "-t":
+                    {
+                        if (values.Length - index < 2)
+                        {
+                            throw new InvalidDataException(string.Concat("A ", statement, " -t option must specify at least 2 values."));
+                        }
+
+                        var turbulence = new ObjVector3();
+
+                        turbulence.X = float.Parse(values[index + 1], CultureInfo.InvariantCulture);
+                        index++;
+
+                        if (values.Length - index > 2)
+                        {
+                            if (float.TryParse(values[index + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out var v))
+                            {
+                                turbulence.Y = v;
+                                index++;
+                            }
+                            else
+                            {
+                                map.Turbulence = turbulence;
+                                break;
+                            }
+
+                            if (values.Length - index > 2)
+                            {
+                                if (float.TryParse(values[index + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out v))
+                                {
+                                    turbulence.Z = v;
                                     index++;
                                 }
                                 else
@@ -941,25 +944,12 @@ namespace JeremyAnsel.Media.WavefrontObj
                                     map.Turbulence = turbulence;
                                     break;
                                 }
-                            
-                                if (values.Length - index > 2)
-                                {
-                                    if (float.TryParse(values[index + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out v))
-                                    {
-                                        turbulence.Z = v;
-                                        index++;
-                                    }
-                                    else
-                                    {
-                                        map.Turbulence = turbulence;
-                                        break;
-                                    }
-                                }
                             }
-
-                            map.Turbulence = turbulence;
-                            break;
                         }
+
+                        map.Turbulence = turbulence;
+                        break;
+                    }
 
                     case "-texres":
                         if (values.Length - index < 2)
@@ -973,26 +963,28 @@ namespace JeremyAnsel.Media.WavefrontObj
                         break;
 
                     default:
+                    {
+                        if (settings.KeepWhitespacesOfMapFileReferences)
                         {
-                            if (settings.KeepWhitespacesOfMapFileReferences)
+                            var charsRead = 0;
+                            for (var i = 1; i < index; i++)
                             {
-                                var charsRead = 0;
-                                for (var i = 1; i < index; i++)
-                                {
-                                    charsRead += values[i].Length;
-                                }
-                                map.FileName = currentLine.Remove(0, statement.Length + charsRead + index);
+                                charsRead += values[i].Length;
                             }
-                            else
-                            {
-                                string filename = string.Join(" ", values, index, values.Length - index);
 
-                                map.FileName = filename; 
-                            }
-                            index = values.Length;
-                            
-                            break;
+                            map.FileName = currentLine.Remove(0, statement.Length + charsRead + index);
                         }
+                        else
+                        {
+                            string filename = string.Join(" ", values, index, values.Length - index);
+
+                            map.FileName = filename;
+                        }
+
+                        index = values.Length;
+
+                        break;
+                    }
                 }
             }
 

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjMaterialFileReader9.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjMaterialFileReader9.cs
@@ -1243,11 +1243,6 @@ namespace JeremyAnsel.Media.WavefrontObj
                                     index++;
                                     charsRead += value2.Length;
                                 }
-                                else
-                                {
-                                    map.Offset = offset;
-                                    break;
-                                }
                             }
                         }
                         
@@ -1302,11 +1297,6 @@ namespace JeremyAnsel.Media.WavefrontObj
                                     index++;
                                     charsRead += value2.Length;
                                 }
-                                else
-                                {
-                                    map.Scale = scale;
-                                    break;
-                                }
                             }
                         }
 
@@ -1360,11 +1350,6 @@ namespace JeremyAnsel.Media.WavefrontObj
                                     turbulence.Z = value;
                                     index++;
                                     charsRead += value2.Length;
-                                }
-                                else
-                                {
-                                    map.Turbulence = turbulence;
-                                    break;
                                 }
                             }
                         }

--- a/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjMaterialFileWriter.cs
+++ b/JeremyAnsel.Media.WavefrontObj/JeremyAnsel.Media.WavefrontObj/ObjMaterialFileWriter.cs
@@ -247,7 +247,7 @@ internal static class ObjMaterialFileWriter
             stream.Write(" spectral ");
             stream.Write(color.SpectralFileName);
 
-            if (color.SpectralFactor != 1.0f)
+            if (Math.Abs(color.SpectralFactor - 1.0f) > float.Epsilon)
             {
                 stream.Write(' ');
                 stream.Write(color.SpectralFactor.ToString("F6", CultureInfo.InvariantCulture));
@@ -338,7 +338,7 @@ internal static class ObjMaterialFileWriter
             }
         }
 
-        if (map.ModifierBase != 0.0f || map.ModifierGain != 1.0f)
+        if (map.ModifierBase != 0.0f || Math.Abs(map.ModifierGain - 1.0f) > float.Epsilon)
         {
             stream.Write(" -mm ");
             stream.Write(map.ModifierBase.ToString("F6", CultureInfo.InvariantCulture));
@@ -360,7 +360,7 @@ internal static class ObjMaterialFileWriter
 
         ObjVector3 scale = map.Scale;
 
-        if (scale.X != 1.0f || scale.Y != 1.0f || scale.Z != 1.0f)
+        if (Math.Abs(scale.X - 1.0f) > float.Epsilon || Math.Abs(scale.Y - 1.0f) > float.Epsilon || Math.Abs(scale.Z - 1.0f) > float.Epsilon)
         {
             stream.Write(" -s ");
             stream.Write(scale.X.ToString("F6", CultureInfo.InvariantCulture));

--- a/JeremyAnsel.Media.WavefrontObj/global.json
+++ b/JeremyAnsel.Media.WavefrontObj/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.0",
+    "version": "10.0.103",
     "rollForward": "feature"
   },
   "test": {


### PR DESCRIPTION
Hi,
the PR adds the flag `HandleEachGroupOccurrenceAsNewGroup` for the `ObjFileReaderSettings`.

Target of the flag is to configure how groups are interpreted. The way the current implementation of the library handles the group names is totally fine and correct for me.

I have looked at the tinyobjreader and have noticed that the tinyobjreader always creates new groups when the keyword is used.
So the need is to create a flag to ensure the compability to the tinyobjreader and ensure e.g. the index of the group is identical when the file is read. 

```
g cube
f 1 2 3
g other
f 4 5 6
g cube
f 7 8 9
```

When the flag is `false` (the default way) the first and last face is assigned to the group `cube`. The second face is assigned to the group `other`
When the flag is `true` the first face is assigned to a group named `cube`, the second face is assigned to a group `other` and the last face is assigned to a independant group with the name `cube`. 

The writing part still creates a fixed version when the groups are not sequential.

Here are some examples for the writing part
```
v 1 0 0
v 2 0 0
v 3 0 0
v 4 0 0
v 5 0 0
v 6 0 0
v 7 0 0
v 8 0 0
v 9 0 0
g cube
f 1 2 3
g cube
f 7 8 9
```
goes to
```
v 1.000000 0.000000 0.000000
v 2.000000 0.000000 0.000000
v 3.000000 0.000000 0.000000
v 4.000000 0.000000 0.000000
v 5.000000 0.000000 0.000000
v 6.000000 0.000000 0.000000
v 7.000000 0.000000 0.000000
v 8.000000 0.000000 0.000000
v 9.000000 0.000000 0.000000
g cube
f 1 2 3
f 7 8 9
```

But
```
v 1 0 0
v 2 0 0
v 3 0 0
v 4 0 0
v 5 0 0
v 6 0 0
v 7 0 0
v 8 0 0
v 9 0 0
g cube
f 1 2 3
g other
f 4 5 6
g cube
f 7 8 9
```

Keeps the same (except the formatting of the floats). So it only merge two sequential groups with the same name.

When it is okay for you I would leave the write side as is. I have an idea how to solve it. I could add a WriterSettings object with the flags to create also different groups and respecting the object references instead of the string equality. Please let me know if this is okay to you to leave the write side as is.

Have a nice day, thank you